### PR TITLE
main v.0.1.5

### DIFF
--- a/dont stop now/main.py
+++ b/dont stop now/main.py
@@ -7,6 +7,7 @@ class Program:
 
     def __init__(self) -> None:
         self.running = True
+        self.memory = dsnclass.Memory()
 
     def run(self, width, height, current_scene):
         """
@@ -15,27 +16,33 @@ class Program:
         """
         screen = pygame.display.set_mode([width, height])
         scene = current_scene
-        memory = dsnclass.Memory()
         while self.running:
             keys_pressed = []
             keys_held = pygame.key.get_pressed()
             for event in pygame.event.get():
+                # Quit condition if you press the X on the top right
                 if event.type == pygame.QUIT:
-                    # Quit condition if you press the X on the top right
                     self.running = False
                     scene.run_scene = False
                 if event.type == pygame.KEYDOWN:
                     keys_pressed.append(event.key)
 
-            if not scene.run_scene:
-                # Stop the game using other conditions
-                scene.close_game()
+            # Stop the game using other conditions
+            if self.running and not scene.run_scene:
                 self.running = False
+                scene.close_game()
             else:
                 scene.input(keys_pressed, keys_held)
                 scene.update()
                 scene.render(screen)
                 scene = scene.this_scene
+
+                # Check for a valid level, then if level done, record data
+                if -1 < scene.level_id and \
+                        scene.victory_counter == len(scene.victory_text):
+                    self.memory.update_mem(scene.level_id, scene.deaths,
+                                           scene.player.jumps)
+                    #print(self.memory.level_progress, self.memory.level_jumps, self.memory.level_deaths)
 
             fps.tick(240)
             pygame.display.update()


### PR DESCRIPTION
Changed pause + quit (with q) to set self.run_scene to False instead of closing game to avoid crashing. Also altered main to complement these changes, allowing the game to be closed (not scene.run_scene) with a button press (in the levels) while the game is still running (self.running), seen in line 30. Added function to the Memory class in main and in the Levels and level_id to Scene. Levels with id lesser than -1 are invalid levels (such as filler, or options/credits in the future). Level id's greater than -1 are actual levels with their own death/jump statistics. Level ID is also used to track the player's level progress by adding the most recently played game to it's dictionary. Exact changes can be seen in the Memory class in dsn_class. MenuScene now has a jump counter, but doesn't have a death counter (as you cannot die in the menu, yet). Main was changed to have memory and record data. It will always record data in the menu as soon as the update function runs. In contrast, the data will only be recorded for levels once it has been beaten. Both are still inefficient processes as the menu is always recording and updating, and the levels have a burst in recording data (during the level transition). There was an additional bug fix where the player would sink into the platform for each bounce it did. This update is in addition to dsn_class and dsn_level v.0.1.6.