### PR TITLE
main v.0.1.6

### DIFF
--- a/dont stop now/main.py
+++ b/dont stop now/main.py
@@ -32,17 +32,23 @@ class Program:
                 self.running = False
                 scene.close_game()
             else:
+                # Check for a valid level, then if level done, record data
+                if 0 < scene.level_id and 3 <= scene.victory_counter and \
+                        500 <= pygame.time.get_ticks() - scene.victory_time:
+                    self.memory.update_mem(scene.level_id, scene.deaths,
+                                           scene.player.jumps)
+                    """print(self.memory.level_progress, self.memory.level_jumps,
+                          self.memory.level_deaths)"""
+                elif scene.level_id == 0 and 3 <= scene.victory_counter:
+                    self.memory.update_mem(scene.level_id, scene.deaths,
+                                           scene.player.jumps)
+                    """print(self.memory.level_progress, self.memory.level_jumps,
+                          self.memory.level_deaths)"""
+
                 scene.input(keys_pressed, keys_held)
                 scene.update()
                 scene.render(screen)
                 scene = scene.this_scene
-
-                # Check for a valid level, then if level done, record data
-                if -1 < scene.level_id and \
-                        scene.victory_counter == len(scene.victory_text):
-                    self.memory.update_mem(scene.level_id, scene.deaths,
-                                           scene.player.jumps)
-                    #print(self.memory.level_progress, self.memory.level_jumps, self.memory.level_deaths)
 
             fps.tick(240)
             pygame.display.update()


### PR DESCRIPTION
Finally a main update. The memory is updated first before any scene's are updated/checked (if statement put before scene methods). The memory update is only called when the level is complete (victory counter and time passed) before changing scenes, which will update the victory counter to not update more than once. This is apart of fixing the memory update bug occurring more than once.