### PR TITLE
main v.0.2.0

### DIFF
--- a/dont stop now/main.py
+++ b/dont stop now/main.py
@@ -39,11 +39,13 @@ class Program:
                         500 <= pygame.time.get_ticks() - scene.victory_time):
                     # Update level memory or menu memory
                     self.memory.update_mem(scene.level_id, scene.deaths,
-                                           scene.player.jumps)
+                                           scene.player.jumps, scene.start_time)
                     scene.level_id += 1
                 elif scene.level_id == 0 and 3 <= scene.victory_counter:
                     self.memory.update_mem(scene.level_id, scene.deaths,
-                                           scene.player.jumps)
+                                           scene.player.jumps, scene.start_time)
+                    scene.start_time = pygame.time.get_ticks()
+
 
                 scene.input(keys_pressed, keys_held)
                 scene.update()


### PR DESCRIPTION
- Created level times and total times, which is viewable in the stats page.
	- main, LevelScene (dsn_levels) and Memory (dsn_class) had time added
	- Furthermore, the static function (not a class), convert_time was added
	- Added another static function called add_time to not overwrite but combine times. This would be useful for updating the menu time and in the future, total play time when saving is implemented
	- Currently, total time is only the time for that session because there's no way to save previous game instances yet
	
- Also added total jumps and total deaths for the statistics 
- In a future update, the time statistics will include miliseconds to consider memory updating in less than a second (which matters most in menuscene).
- Made update_stats function in the StatsPage class to update the text whenever needed (less messy)