### PR TITLE
dsn_patch_4

### DIFF
--- a/dont stop now/dsn_class.py
+++ b/dont stop now/dsn_class.py
@@ -695,7 +695,7 @@ class SquareMe:  # lil purple dude
 
     def gravity(self):
         if self.enable_gravity and not self.jump_ability:
-            gravity_y = ((self.gravity_counter ** 2) * 0.00015) / self.diff_factor
+            gravity_y = ((self.gravity_counter ** 2) * 0.00015)
             self.ypos += gravity_y * self.diff_factor
 
         if self.gravity_counter < 1100:

--- a/dont stop now/dsn_levels.py
+++ b/dont stop now/dsn_levels.py
@@ -20,9 +20,10 @@ BROWN = (150, 75, 0)
 LICORICE_BLACK = (52, 52, 52)
 
 # todo: move to main loop
-dont_image_text = pygame.image.load("dont (custom).png")  # ratio is 15:8
-stop_image_text = pygame.image.load("stop (custom).png")
-now_image_text = pygame.image.load("now (custom).png")
+file_path = "assets/images/"
+dont_image_text = pygame.image.load(file_path + "dont (Custom).png")  # ratio is 15:8
+stop_image_text = pygame.image.load(file_path + "stop (Custom).png")
+now_image_text = pygame.image.load(file_path + "now (Custom).png")
 
 
 class LevelScene(dsnclass.Scene):
@@ -103,7 +104,7 @@ class LevelScene(dsnclass.Scene):
             # Pressing/tapping and not holding jump key to jump
             if every_key in [pygame.K_w, pygame.K_UP, pygame.K_SPACE] and not \
                     self.player.enable_gravity and self.player.alive and not \
-                    self.player.freeze and 200 <= pygame.time.get_ticks() - self.jump_timer:
+                    self.player.freeze and 150 <= pygame.time.get_ticks() - self.jump_timer:
                 self.player.jump_ability = True # Allow player to jump
                 self.player.jump_boost = self.player.max_jump   # Setup jump
                 self.player.jump_sound_1.play()     # Play jump sound
@@ -132,6 +133,7 @@ class LevelScene(dsnclass.Scene):
 
             # Press b to go back to main menu
             if self.player.freeze and every_key == pygame.K_b:
+                self.memory.music.set_music(0, self.memory.music.max_vol, -1, 0, 0)
                 self.change_scene(MenuScene(40, 360, self.memory))
 
         # Held controls for jumping
@@ -235,6 +237,12 @@ class LevelScene(dsnclass.Scene):
             self.play_time = pygame.time.get_ticks()
             self.victory_time = pygame.time.get_ticks()
 
+        if pygame.time.get_ticks() - self.memory.music.text_timer < 3000:
+            pygame.draw.rect(screen, YELLOW,
+                             self.memory.music.music_text.text_rect)
+            screen.blit(self.memory.music.music_text.text_img,
+                        self.memory.music.music_text.text_rect)
+
 
 class MenuScene(LevelScene):
     """
@@ -300,6 +308,7 @@ class MenuScene(LevelScene):
         for every_key in pressed:
             # If player chooses option, update menu statistics and change scene
             if every_key in [pygame.K_SPACE, pygame.K_w]:
+                self.memory.music.switch_music()
                 self.memory.update_mem(self.level_id, self.deaths,
                                        self.player.jumps, self.start_time)
                 self.change_scene(self.options[self.option_count])
@@ -387,6 +396,7 @@ class Filler(dsnclass.Scene):
         for every_key in pressed:
             # Pressing R allows you to go back
             if every_key == pygame.K_r:
+                self.memory.music.set_music(0, self.memory.music.max_vol, -1, 0, 0)
                 self.change_scene(MenuScene(40, 360, self.memory))
 
     def render(self, screen):
@@ -438,6 +448,7 @@ class OptionsPage(LevelScene):
 
             # If press "R", return to main menu
             if action is pygame.K_r:
+                self.memory.music.set_music(0, self.memory.music.max_vol, -1, 0, 0)
                 self.change_scene(MenuScene(40, 360, self.memory))
 
     def update(self):
@@ -541,6 +552,7 @@ class StatsPage(LevelScene):
         for action in pressed:
             # Always display the return message
             if action == pygame.K_r:
+                self.memory.music.set_music(0, self.memory.music.max_vol, -1, 0, 0)
                 self.change_scene(MenuScene(40, 360, self.memory))
 
     def update(self):
@@ -645,6 +657,7 @@ class LevelSelect(LevelScene):
         for every_key in pressed:
             # Return player to menu if pressing "R"
             if every_key == pygame.K_r:
+                self.memory.music.set_music(0, self.memory.music.max_vol, -1, 0, 0)
                 self.change_scene(MenuScene(40, 360,self.memory))
 
             # Allow player to choose a level (based on ID) after 0.405 seconds

--- a/dont stop now/main.py
+++ b/dont stop now/main.py
@@ -2,6 +2,7 @@ import pygame
 import dsn_levels as dsnlevel
 import dsn_class as dsnclass
 
+
 class Program:
     """
     Class responsible for how the game runs
@@ -41,16 +42,23 @@ class Program:
                 # Quit condition if you press the X on the top right
                 if event.type == pygame.QUIT:
                     self.running = False    # Stop running this loop
+                    pygame.mixer.music.stop()   # Stop the music
                     scene.run_scene = False     # Tell scene to stop running
                 # If player does a keypress, append to our list for key presses
                 if event.type == pygame.KEYDOWN:
                     keys_pressed.append(event.key)
 
+                if event.type == self.memory.music.end:
+                    self.memory.music.switch_music()
+
             # Stop the game using other conditions (running, but scene says off)
             if self.running and not scene.run_scene:
                 self.running = False    # Stop running this loop
+                pygame.mixer.music.stop()   # Stop the music
                 scene.close_game()      # Tell scene to shut off
             else:
+                # Functional game loop
+
                 scene.input(keys_pressed, keys_held)    # Call to use keys in
                 scene.update()  # Call to dynamically use/update/check changes
                 scene.render(screen)    # Visually render desired graphics
@@ -61,16 +69,20 @@ class Program:
                 changed and will continue being this scene (same memory
                 address, no change)."""
 
+                if 0 != scene.level_id:
+                    self.memory.music.transition_music()
+
             fps.tick(120)   # 120 frames per second
             pygame.display.update()     # Update the visual output dynamically
 
 
 if __name__ == "__main__":
     pygame.init()   # Initialize pygame
-    pygame.mixer.init() # Initialize pygame's sound
+    pygame.mixer.init()  # Initialize pygame's sound
     fps = pygame.time.Clock()   # Initialize the frame rate
-    pygame.display.set_caption("Dont Stop Now") # game window caption
-    icon = pygame.image.load("rect10.png") # loading image
+    file_path = "assets/images/"
+    pygame.display.set_caption(file_path + "Dont Stop Now") # game window caption
+    icon = pygame.image.load(file_path + "rect10.png") # loading image
     default_icon_image_size = (32, 32) # reducing size of image
     icon = pygame.transform.scale(icon, default_icon_image_size) # scaling image correctly
     pygame.display.set_icon(icon) # game window icon


### PR DESCRIPTION
Added Music to the game:
- Moved Music to be used in the scope of the main loop. It's specifically initialized in Memory's init. Memory is passed throughout each Scene instance and allows it to be updated between scenes if necessary. A good example is switching between the menu (always playing menu music) and any other scene (random).
- Music has been updated to have these functions:
1. swich_music which will randomly choose a track (that's not menu and not credits)
2. set_music which will allow a specific music track to be chosen along with specific volume settings, how many times it'll loop, start time, and how much miliseconds it takes to fade in (optional)
3. transition_music which uses time to eventually increase the volume

=====

Other small changes include altering the jump to be less delayed (200 --> 150 milliseconds, issue #234) and removing a redundant self.diff_factor in gravity (issue #244). 