### PR TITLE
dsn_patch_10

### DIFF
--- a/dont stop now/dsn_levels.py
+++ b/dont stop now/dsn_levels.py
@@ -14,10 +14,10 @@ ORANGE = (255, 165, 0)
 BLUE = (30, 144, 255)
 GREY = (125, 125, 125)
 LIGHT_PINK = (255, 182, 193)
-EDIT_DARK_GREEN = (1, 100, 32)
+DARK_GREEN = (1, 100, 32)
 PURPLE = (181, 60, 177)
 BROWN = (150, 75, 0)
-LICORICE_BLACK = (52, 52, 52)
+DARK_GREY = (52, 52, 52)
 
 # todo: move to main loop
 file_path = "assets/images/"

--- a/dont stop now/dsn_levels.py
+++ b/dont stop now/dsn_levels.py
@@ -689,7 +689,11 @@ class ReplayIO(LevelScene):
 
                 # Text in
                 elif self.choose_counter == 1:
-                    in_str = str(pygame.scrap.get(pygame.SCRAP_TEXT), "utf-8")
+                    if 0 < len(str(pygame.scrap.get(pygame.SCRAP_TEXT), "utf-8")) or \
+                            str(pygame.scrap.get(pygame.SCRAP_TEXT), "utf-8") is not None:
+                        in_str = str(pygame.scrap.get(pygame.SCRAP_TEXT), "utf-8")
+                    else:
+                        in_str = ""
                     if 9 < len(in_str) and ", " in in_str and \
                             "[" in in_str and "]" in in_str:
                         in_list = in_str[1:-1].split(", ")


### PR DESCRIPTION
**Various Small Changes:**

_Collision_
- Fixed player going into and below or above small blocks when colliding on the side. This was due to the "first line of defense" not switching player direction (and causing the player to go inside). This triggered the "last line of defense" and put the player outside of the block.
- In general, added a full reset for jump/movement/gravity when the "first line of defense" is triggered for collision. This will fix #278 

_Replays_
- Changed it so Replays now take in forced respawns (by ESC and pressing R), which will fix #274 
- Replay information now relies on game loop iterations (how many loops has passed) rather than pygame.time.get_ticks(). (Details) Before, pygame time would yield varied results because several game loops could had passed before the time conditions were met. The timings were dependent on the interval that the player selected replays (aka it just varied). Therefore, the resulting actions the replayer took were rarely on point and mostly delayed. Using game loops will provide near exact timing for when the replayer should do their actions.
- The Replays page now has help text to assist the player in using the Replays feature.
- Replays now have text in/text out options (copy/paste)
- Replays is fully functioning (resolves #248) 

_Options/Settings_
- Reworked Settings/Options to be a bit more clean and smart (but likely just as inefficient).
- Music selection was removed from settings/options.
- Settings/Options now have a slider to change the background between WHITE and LIGHT_GREY. However, the slider uses A/D and not the mouse (since we have only been using keyboard so far). This resolves issue #197 
- Settings/Options also have a held function that will speed up the selection the longer the player holds A/D.